### PR TITLE
Fix ID handling for new_version method

### DIFF
--- a/inveniordm_py/resources.py
+++ b/inveniordm_py/resources.py
@@ -43,10 +43,11 @@ class Resource:
         """Get endpoint arguments.
 
         Arguments are computed from the data and the resource.
-        Precedence is given to the resource endpoint kwargs.
+        Precedence is given to the data returned from the API call, as 
+        the resource endpoint kwargs are in some cases already set before the API call
         """
         if isinstance(self.data, Metadata):
-            return {**self.data.endpoint_kwargs, **self._endpoint_args}
+            return {**self._endpoint_args, **self.data.endpoint_kwargs}
         return self._endpoint_args
 
     @data.setter

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -29,6 +29,17 @@ def test_create_with_data(client):
     assert draft.data["id"] is not None
 
 
+def test_new_version_endpoints(client):
+    """Test endpoints for new versions are set correctly"""
+
+    # Create record with non-default id_
+    record = Record(client=client, id_="101")
+    draft = record.new_version()
+
+    # ensure response data id_ has priority over parent resource id_
+    assert draft.endpoint_args["id_"] != record.endpoint_args["id_"]
+
+
 def test_update(client):
     """Test case for updating a draft.
 


### PR DESCRIPTION
### Description

This PR ensures a draft object generated via record.new_version does use the new endpoint ID provided by the server response. This is achieved by giving priority to `data` values over `_endpoint_args`.

Fixes #11 



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
